### PR TITLE
Add support for detached topics

### DIFF
--- a/xmind/core/const.py
+++ b/xmind/core/const.py
@@ -67,6 +67,7 @@ VAL_FOLDED = "folded"
 
 TOPIC_ROOT = "root"
 TOPIC_ATTACHED = "attached"
+TOPIC_DETACHED = "detached"
 
 FILE_PROTOCOL = "file://"
 TOPIC_PROTOCOL = "xmind:#"


### PR DESCRIPTION
the const.py was missing a constant to support this.
obviously this can be done by sending the "detached" string directly to "topic.getSubTopics()" but it makes it more elegant and easier to spot.

Regards,
- Jony
